### PR TITLE
RT-258 Add Prometheus Metrics exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Exporter Metrics 
+exporter_metrics

--- a/src/vulnrelay/core/conf.py
+++ b/src/vulnrelay/core/conf.py
@@ -27,6 +27,10 @@ class Settings(BaseSettings):
     SCANNERS: list[ScannerOption] = ["grype"]
     SCAN_HOST: bool = False
 
+    # Metric Exporter Settings
+    METRICS_DIR: str = "exporter_metrics"
+    METRICS_FILENAME: str = "vulnrelay.prom"
+
     model_config = SettingsConfigDict(
         env_file=ROOT_DIR / ".env",
     )

--- a/src/vulnrelay/metrics/__init__.py
+++ b/src/vulnrelay/metrics/__init__.py
@@ -1,4 +1,4 @@
 from .exporter import MetricExporter
 from .metric import MetricNames
 
-__all__ = ["MetricExporter", "Metric", "MetricNames"]
+__all__ = ["MetricExporter", "MetricNames"]

--- a/src/vulnrelay/metrics/__init__.py
+++ b/src/vulnrelay/metrics/__init__.py
@@ -1,4 +1,4 @@
 from .exporter import MetricExporter
-from .metric import Metric, MetricNames
+from .metric import MetricNames
 
 __all__ = ["MetricExporter", "Metric", "MetricNames"]

--- a/src/vulnrelay/metrics/__init__.py
+++ b/src/vulnrelay/metrics/__init__.py
@@ -1,0 +1,4 @@
+from .exporter import MetricExporter
+from .metric import Metric, MetricNames
+
+__all__ = ["MetricExporter", "Metric", "MetricNames"]

--- a/src/vulnrelay/metrics/exporter.py
+++ b/src/vulnrelay/metrics/exporter.py
@@ -1,0 +1,42 @@
+import os
+import shutil
+from typing import Any
+
+from .metric import Metric
+
+
+class MetricExporter:
+    def __init__(self, *, metrics: dict[str, Metric], path: str) -> None:
+        self.metrics: dict[str, Metric] = metrics
+        self.path = path
+        self.check_dir()
+
+    def _get_export_content(self) -> str:
+        return "\n".join([f"{name} {metric.last_output}" for name, metric in self.metrics.items()])
+
+    def check_dir(self) -> None:
+        dir = os.path.dirname(self.path)
+        if not os.path.exists(dir):
+            os.makedirs(dir)
+
+    def export_all(self) -> None:
+        content = self._get_export_content()
+        path = self.path
+        temp_file = f"{path}.tmp"
+
+        if os.path.exists(path):
+            os.remove(path)
+
+        with open(temp_file, "w") as file:
+            file.write(content)
+
+        try:
+            shutil.move(temp_file, path)
+        except Exception as e:
+            os.remove(temp_file)
+            raise e
+
+    def save_and_export(self, *, values: dict[str, Any]) -> None:
+        for name, value in values.items():
+            self.metrics[name].save_output(value=value)
+        self.export_all()

--- a/src/vulnrelay/metrics/exporter.py
+++ b/src/vulnrelay/metrics/exporter.py
@@ -1,31 +1,26 @@
 import os
 import shutil
+from pathlib import Path
 from typing import Any
-
-from .metric import Metric
 
 
 class MetricExporter:
-    def __init__(self, *, metrics: dict[str, Metric], path: str) -> None:
-        self.metrics: dict[str, Metric] = metrics
+    def __init__(self, *, metrics: dict[str, Any], path: str) -> None:
+        self.metrics: dict[str, Any] = metrics
         self.path = path
-        self.check_dir()
+        self._check_dir()
 
     def _get_export_content(self) -> str:
-        return "\n".join([f"{name} {metric.last_output}" for name, metric in self.metrics.items()])
+        return "\n".join([f"{name} {metric}" for name, metric in self.metrics.items()])
 
-    def check_dir(self) -> None:
-        dir = os.path.dirname(self.path)
-        if not os.path.exists(dir):
-            os.makedirs(dir)
+    def _check_dir(self) -> None:
+        dir_path = Path(self.path).parent
+        dir_path.mkdir(parents=True, exist_ok=True)
 
     def export_all(self) -> None:
         content = self._get_export_content()
         path = self.path
         temp_file = f"{path}.tmp"
-
-        if os.path.exists(path):
-            os.remove(path)
 
         with open(temp_file, "w") as file:
             file.write(content)
@@ -38,5 +33,5 @@ class MetricExporter:
 
     def save_and_export(self, *, values: dict[str, Any]) -> None:
         for name, value in values.items():
-            self.metrics[name].save_output(value=value)
-        self.export_all()
+            self.metrics[name] = value
+            self.export_all()

--- a/src/vulnrelay/metrics/exporter.py
+++ b/src/vulnrelay/metrics/exporter.py
@@ -3,15 +3,17 @@ import shutil
 from pathlib import Path
 from typing import Any
 
+from .metric import MetricNames
+
 
 class MetricExporter:
-    def __init__(self, *, metrics: dict[str, Any], path: str) -> None:
-        self.metrics: dict[str, Any] = metrics
+    def __init__(self, *, path: Path) -> None:
+        self.metrics: dict[MetricNames, Any] = dict()
         self.path = path
         self._check_dir()
 
     def _get_export_content(self) -> str:
-        return "\n".join([f"{name} {metric}" for name, metric in self.metrics.items()])
+        return "\n".join([f"{name.value} {metric}" for name, metric in self.metrics.items()])
 
     def _check_dir(self) -> None:
         dir_path = Path(self.path).parent
@@ -20,7 +22,7 @@ class MetricExporter:
     def export_all(self) -> None:
         content = self._get_export_content()
         path = self.path
-        temp_file = f"{path}.tmp"
+        temp_file = self.path.with_suffix(".tmp")
 
         with open(temp_file, "w") as file:
             file.write(content)
@@ -31,7 +33,7 @@ class MetricExporter:
             os.remove(temp_file)
             raise e
 
-    def save_and_export(self, *, values: dict[str, Any]) -> None:
+    def save_and_export(self, *, values: dict[MetricNames, Any]) -> None:
         for name, value in values.items():
             self.metrics[name] = value
             self.export_all()

--- a/src/vulnrelay/metrics/metric.py
+++ b/src/vulnrelay/metrics/metric.py
@@ -1,22 +1,5 @@
 from enum import Enum
-from typing import Any
 
 
 class MetricNames(Enum):
     LAST_SCAN_AND_PUSH = "last_successful_scan_push"
-
-
-class Metric:
-    def __init__(self, *, last_output: Any | None = None) -> None:
-        self.outputs = []
-        if last_output:
-            self.outputs.append(last_output)
-
-    @property
-    def last_output(self) -> Any | None:
-        if len(self.outputs) == 0:
-            return None
-        return self.outputs[-1]
-
-    def save_output(self, value: Any) -> None:
-        self.outputs.append(value)

--- a/src/vulnrelay/metrics/metric.py
+++ b/src/vulnrelay/metrics/metric.py
@@ -1,0 +1,22 @@
+from enum import Enum
+from typing import Any
+
+
+class MetricNames(Enum):
+    LAST_SCAN_AND_PUSH = "last_successful_scan_push"
+
+
+class Metric:
+    def __init__(self, *, last_output: Any | None = None) -> None:
+        self.outputs = []
+        if last_output:
+            self.outputs.append(last_output)
+
+    @property
+    def last_output(self) -> Any | None:
+        if len(self.outputs) == 0:
+            return None
+        return self.outputs[-1]
+
+    def save_output(self, value: Any) -> None:
+        self.outputs.append(value)

--- a/src/vulnrelay/services.py
+++ b/src/vulnrelay/services.py
@@ -1,8 +1,8 @@
 import logging
-import os
 import subprocess
 import time
 from collections.abc import Callable, Iterable
+from pathlib import Path
 
 from vulnrelay.core.conf import settings
 from vulnrelay.metrics import MetricExporter, MetricNames
@@ -42,10 +42,7 @@ def get_uploader() -> Uploader:
 
 def get_metric_exporter() -> MetricExporter:
     return MetricExporter(
-        metrics={
-            MetricNames.LAST_SCAN_AND_PUSH.value: None,
-        },
-        path=os.path.join(settings.METRICS_DIR, settings.METRICS_FILENAME),
+        path=Path(settings.METRICS_DIR) / settings.METRICS_FILENAME,
     )
 
 
@@ -114,7 +111,7 @@ def run_workflow(
 
     try:
         metric_exporter.save_and_export(
-            values={MetricNames.LAST_SCAN_AND_PUSH.value: int(time.time())},
+            values={MetricNames.LAST_SCAN_AND_PUSH: time.time()},
         )
     except Exception:
         logger.exception("Failed to export metrics!")

--- a/src/vulnrelay/services.py
+++ b/src/vulnrelay/services.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Callable, Iterable
 
 from vulnrelay.core.conf import settings
-from vulnrelay.metrics import Metric, MetricExporter, MetricNames
+from vulnrelay.metrics import MetricExporter, MetricNames
 from vulnrelay.scanners import Scanner
 from vulnrelay.uploader import DefectDojoUploader, Uploader
 
@@ -43,7 +43,7 @@ def get_uploader() -> Uploader:
 def get_metric_exporter() -> MetricExporter:
     return MetricExporter(
         metrics={
-            MetricNames.LAST_SCAN_AND_PUSH.value: Metric(),
+            MetricNames.LAST_SCAN_AND_PUSH.value: None,
         },
         path=os.path.join(settings.METRICS_DIR, settings.METRICS_FILENAME),
     )

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,0 +1,16 @@
+import tempfile
+import time
+from pathlib import Path
+
+from vulnrelay.metrics.exporter import MetricExporter
+from vulnrelay.metrics.metric import MetricNames
+
+
+def test_export_metrics():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        metric_exporter = MetricExporter(path=Path(temp_dir) / "test.prom")
+        metric_exporter.save_and_export(
+            values={
+                MetricNames.LAST_SCAN_AND_PUSH: time.time(),
+            },
+        )

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -8,9 +8,15 @@ from vulnrelay.metrics.metric import MetricNames
 
 def test_export_metrics():
     with tempfile.TemporaryDirectory() as temp_dir:
-        metric_exporter = MetricExporter(path=Path(temp_dir) / "test.prom")
+        path = Path(temp_dir) / "test.prom"
+        metric_exporter = MetricExporter(path=path)
+        timestamp = time.time()
         metric_exporter.save_and_export(
             values={
-                MetricNames.LAST_SCAN_AND_PUSH: time.time(),
+                MetricNames.LAST_SCAN_AND_PUSH: timestamp,
             },
         )
+
+        with open(path) as file:
+            contents: str = file.read()
+            assert contents == f"{MetricNames.LAST_SCAN_AND_PUSH.value} {timestamp}"


### PR DESCRIPTION
**Intent:**
This is part of RT-258. The other part will soon be another pull request to the Django Template.

**Summary of changes:** 

We're exporting metrics to a customizable (through env vars) directory in the Prometheus .prom format. We have a default metric that states the last scan and push that occurred. Apart from it, there is already groundwork for making new metrics on the fly should we need to.